### PR TITLE
Enhance PSI and confusion plots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Virtual environments
+.venv/
+.env/
+
+# Data and model files
+*.pkl
+*.joblib
+
+# Jupyter notebooks
+*.ipynb
+.ipynb_checkpoints/
+
+# Output images
+*.png

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.3
+    hooks:
+      - id: ruff

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Requisitos:
   pip install pandas numpy scikit-learn matplotlib seaborn plotly kaleido
   ```
 
+Opcionalmente, instale os ganchos de *pre-commit* para padronizar o código:
+
+```bash
+pre-commit install
+```
+
 ---
 
 ## 🚀 Exemplo Rápido
@@ -88,7 +94,9 @@ print(evaluator.report)
 - Brier Score
 
 ### 🧱 Matriz de Confusão
-- Gráfico Seaborn com cores em contraste
+- Gráfico Plotly com contraste automático de texto
+- Suporta threshold otimizado (``"ks"``/``"youden"``)
+- Pode gerar matrizes por grupo (``group_col``)
 - Mostra valores absolutos e percentuais
 
 ### 🎯 Curva de Calibração
@@ -100,6 +108,8 @@ print(evaluator.report)
 
 ### 🧪 PSI por Variável
 - PSI por variável ao longo do tempo (usando `date_col`)
+- Bins por quantis com base em dataset de referência
+- Tolerante a valores fora do intervalo e períodos com poucos dados
 - Indicação visual de faixas:
   - PSI ≤ 0.10 (aceitável)
   - PSI 0.10–0.25 (monitorar)

--- a/binary_performance_evaluator.py
+++ b/binary_performance_evaluator.py
@@ -1,4 +1,3 @@
-
 """binary_performance_evaluator.py
 -----------------------------------
 A self‑contained utility to evaluate the performance of an *already‑trained* binary
@@ -37,32 +36,42 @@ print(evaluator.report)           # full dict of results
 """
 
 from __future__ import annotations
-import warnings
-import pickle
-from pathlib import Path
-from typing import Dict, List, Optional, Union, Any, Literal
 
+import pickle
+import warnings
+from pathlib import Path
+from typing import Any, Dict, List, Literal, Optional, Union
+
+import joblib
 import numpy as np
 import pandas as pd
-import joblib
-import matplotlib.pyplot as plt
-import seaborn as sns
 import plotly.graph_objects as go
-from optbinning import OptimalBinning
+import seaborn as sns
 from decile_plot import decile_analysis_plot
+from optbinning import OptimalBinning
 from sklearn.calibration import calibration_curve
 from sklearn.metrics import (
-    matthews_corrcoef,
-    roc_auc_score,
     average_precision_score,
-    precision_score,
-    recall_score,
     brier_score_loss,
     confusion_matrix,
+    matthews_corrcoef,
+    precision_score,
+    recall_score,
+    roc_auc_score,
     roc_curve,
 )
 
-sns.set(style='whitegrid')  # consistent style throughout
+sns.set(style="whitegrid")  # consistent style throughout
+
+
+def _psi_single(p_base: np.ndarray, p_test: np.ndarray) -> float:
+    """Compute PSI for two proportional histograms (no zeros allowed)."""
+    mask = (p_base > 0) & (p_test > 0)
+    if not mask.any():
+        return 0.0
+    delta = (p_test[mask] - p_base[mask]) * np.log(p_test[mask] / p_base[mask])
+    return float(delta.sum())
+
 
 class BinaryPerformanceEvaluator:
     """Evaluate binary classifier performance on multiple splits.
@@ -156,69 +165,118 @@ class BinaryPerformanceEvaluator:
     def compute_metrics(self) -> None:
         """Compute numeric metrics for train, test and (optional) validation."""
         self._validate_predictors()
-        splits = {'train': self.df_train, 'test': self.df_test}
+        splits = {"train": self.df_train, "test": self.df_test}
         if self.df_val is not None:
-            splits['val'] = self.df_val
+            splits["val"] = self.df_val
 
         for split_name, df in splits.items():
             y_true = df[self.target_col].values
             y_pred_proba = df[self.score_col_].values
 
             metrics_dict = {
-                'MCC': matthews_corrcoef(y_true, (y_pred_proba >= self.threshold).astype(int)),
-                'AUC_ROC': roc_auc_score(y_true, y_pred_proba),
-                'AUC_PR': average_precision_score(y_true, y_pred_proba),
-                'Precision': precision_score(y_true, (y_pred_proba >= self.threshold).astype(int)),
-                'Recall': recall_score(y_true, (y_pred_proba >= self.threshold).astype(int)),
-                'Brier': brier_score_loss(y_true, y_pred_proba),
+                "MCC": matthews_corrcoef(
+                    y_true, (y_pred_proba >= self.threshold).astype(int)
+                ),
+                "AUC_ROC": roc_auc_score(y_true, y_pred_proba),
+                "AUC_PR": average_precision_score(y_true, y_pred_proba),
+                "Precision": precision_score(
+                    y_true, (y_pred_proba >= self.threshold).astype(int)
+                ),
+                "Recall": recall_score(
+                    y_true, (y_pred_proba >= self.threshold).astype(int)
+                ),
+                "Brier": brier_score_loss(y_true, y_pred_proba),
             }
             self.report[split_name] = metrics_dict
 
-    def plot_confusion(self, *, save: bool = False) -> None:
-        """Plot confusion matrices (absolute + %)."""
-        if not self.report:
-            warnings.warn('compute_metrics() has not been called; metrics may be missing.')
-        self._validate_predictors()
+    def plot_confusion(
+        self,
+        y_true: pd.Series,
+        y_pred_proba: np.ndarray,
+        *,
+        threshold: float | str = 0.5,
+        normalize: bool = False,
+        title: str = "",
+        cmap: str = "Blues",
+        group_col: Optional[pd.Series] = None,
+    ) -> go.Figure | Dict[Any, go.Figure]:
+        """Return confusion matrix figure(s).
 
-        fig, axes = plt.subplots(1, 3 if self.df_val is not None else 2, figsize=(18, 5))
-        split_dfs = {'Train': self.df_train, 'Test': self.df_test}
-        if self.df_val is not None:
-            split_dfs['Val'] = self.df_val
+        Parameters
+        ----------
+        y_true : pd.Series
+            True binary labels.
+        y_pred_proba : np.ndarray
+            Predicted probabilities for the positive class.
+        threshold : float | {"ks", "youden"}, default 0.5
+            Probability threshold or method to determine it.
+        normalize : bool, default False
+            If ``True``, heatmap values are percentages.
+        title : str, default ""
+            Figure title.
+        cmap : str, default "Blues"
+            Plotly colour scale name.
+        group_col : pd.Series, optional
+            When provided, one figure per group will be returned.
+        """
 
-        for ax, (title, df) in zip(axes, split_dfs.items()):
-            y_true = df[self.target_col]
-            y_pred = df[self.label_col_]
-            cm = confusion_matrix(y_true, y_pred)
-            cm_perc = cm / cm.sum()
+        def _best_threshold(method: str) -> float:
+            fpr, tpr, thr = roc_curve(y_true, y_pred_proba)
+            if method == "youden":
+                score = tpr - fpr
+            else:
+                score = tpr - fpr
+            return float(thr[np.argmax(score)])
 
-            sns.heatmap(cm, annot=False, fmt='d', cmap='Blues', cbar=False, ax=ax)
-            ax.set_xticklabels(['0', '1'])
-            ax.set_yticklabels(['0', '1'], rotation=0)
+        if isinstance(threshold, str):
+            threshold = _best_threshold(threshold.lower())
 
-            # annotate abs + %
-            for i in range(cm.shape[0]):
-                for j in range(cm.shape[1]):
-                    abs_val = cm[i, j]
-                    perc_val = cm_perc[i, j]
-                    text_color = 'white' if cm_perc[i, j] > 0.35 else 'black'
-                    ax.text(
-                        j + 0.5,
-                        i + 0.5,
-                        f'{abs_val}\n{perc_val:.1%}',
-                        ha='center',
-                        va='center',
-                        color=text_color,
-                        fontsize=10,
-                        fontweight='bold',
-                    )
-            ax.set_title(f'{title} Confusion Matrix', fontsize=12)
-            ax.set_xlabel('Predicted label')
-            ax.set_ylabel('True label')
+        if group_col is not None:
+            figs: Dict[Any, go.Figure] = {}
+            for group, mask in group_col.groupby(group_col).groups.items():
+                figs[group] = self.plot_confusion(
+                    y_true[mask],
+                    y_pred_proba[mask],
+                    threshold=threshold,
+                    normalize=normalize,
+                    title=f"{title} - {group}" if title else str(group),
+                    cmap=cmap,
+                )
+            return figs
 
-        fig.tight_layout()
-        if save and self.save_dir:
-            plt.savefig(self.save_dir / 'confusion_matrices.png', dpi=200, bbox_inches='tight')
-        plt.show()
+        y_pred = (y_pred_proba >= float(threshold)).astype(int)
+        cm_abs = confusion_matrix(y_true, y_pred, labels=[0, 1])
+        cm_pct = cm_abs / cm_abs.sum()
+        matrix = cm_pct if normalize else cm_abs
+
+        fig = go.Figure(
+            data=go.Heatmap(
+                z=matrix,
+                x=["Pred 0", "Pred 1"],
+                y=["True 0", "True 1"],
+                colorscale=cmap,
+                showscale=False,
+            )
+        )
+        fig.update_yaxes(autorange="reversed")
+
+        for i in range(2):
+            for j in range(2):
+                fig.add_annotation(
+                    x=j,
+                    y=i,
+                    text=f"{cm_abs[i, j]:,}\n({100 * cm_pct[i, j]:.1f}%)",
+                    showarrow=False,
+                    font=dict(color="white" if cm_pct[i, j] > 0.5 else "black"),
+                )
+
+        fig.update_layout(
+            title=title or "Confusion Matrix",
+            xaxis_title="Predicted label",
+            yaxis_title="True label",
+            template="plotly_white",
+        )
+        return fig
 
     def plot_calibration(self, *, n_bins: int = 10, save: bool = False) -> go.Figure:
         """Reliability diagram for test split using Plotly."""
@@ -229,29 +287,35 @@ class BinaryPerformanceEvaluator:
             y_true,
             y_pred_proba,
             n_bins=n_bins,
-            strategy='uniform',
+            strategy="uniform",
         )
 
         brier = brier_score_loss(y_true, y_pred_proba)
 
         fig = go.Figure()
-        fig.add_trace(go.Scatter(x=prob_pred, y=prob_true, mode='lines+markers', name='Model'))
-        fig.add_trace(go.Scatter(x=[0, 1], y=[0, 1], mode='lines', line=dict(dash='dash'), name='Ideal'))
+        fig.add_trace(
+            go.Scatter(x=prob_pred, y=prob_true, mode="lines+markers", name="Model")
+        )
+        fig.add_trace(
+            go.Scatter(
+                x=[0, 1], y=[0, 1], mode="lines", line=dict(dash="dash"), name="Ideal"
+            )
+        )
         fig.update_layout(
-            title=f'Calibration Curve – Test (Brier = {brier:.4f})',
-            xaxis_title='Predicted probability',
-            yaxis_title='Observed frequency',
-            template='plotly_white',
+            title=f"Calibration Curve – Test (Brier = {brier:.4f})",
+            xaxis_title="Predicted probability",
+            yaxis_title="Observed frequency",
+            template="plotly_white",
         )
 
         if save and self.save_dir:
-            fig.write_image(str(self.save_dir / 'calibration_curve.png'))
+            fig.write_image(str(self.save_dir / "calibration_curve.png"))
         return fig
 
     def plot_event_rate(self, *, save: bool = False) -> go.Figure:
         """Trend of event rate over time by group using Plotly."""
         if self.date_col is None:
-            raise ValueError('`date_col` is required for plot_event_rate().')
+            raise ValueError("`date_col` is required for plot_event_rate().")
 
         group_col = None
         for cand in [self.group_col, self.group_col_]:
@@ -259,13 +323,13 @@ class BinaryPerformanceEvaluator:
                 group_col = cand
                 break
         if group_col is None:
-            raise ValueError('Group column not found for plot_event_rate().')
+            raise ValueError("Group column not found for plot_event_rate().")
 
         df_all = pd.concat(
             [
-                self.df_train.assign(Split='Train'),
-                self.df_test.assign(Split='Test'),
-                *( [self.df_val.assign(Split='Val')] if self.df_val is not None else [] )
+                self.df_train.assign(Split="Train"),
+                self.df_test.assign(Split="Test"),
+                *([self.df_val.assign(Split="Val")] if self.df_val is not None else []),
             ],
             axis=0,
         )
@@ -284,93 +348,161 @@ class BinaryPerformanceEvaluator:
                 go.Scatter(
                     x=pivot.index,
                     y=pivot[col],
-                    mode='lines+markers',
+                    mode="lines+markers",
                     name=str(col),
                 )
             )
         fig.update_layout(
-            title='Event Rate by Group over Time',
+            title="Event Rate by Group over Time",
             xaxis_title=self.date_col,
-            yaxis_title='Event rate',
-            template='plotly_white',
+            yaxis_title="Event rate",
+            template="plotly_white",
         )
         if save and self.save_dir:
-            fig.write_image(str(self.save_dir / 'event_rate.png'))
+            fig.write_image(str(self.save_dir / "event_rate.png"))
         return fig
 
-    def plot_psi(self, *, bins: int = 10, save: bool = False) -> go.Figure:
-        """Compute & plot PSI per variable through time using Plotly."""
+    def plot_psi(
+        self,
+        *,
+        reference_df: Optional[pd.DataFrame] = None,
+        bin_strategy: Optional[Dict[str, Any]] = None,
+        min_obs: int = 100,
+        eps: float = 1e-9,
+        save: bool = False,
+    ) -> go.Figure:
+        """Compute and plot PSI per variable through time using Plotly.
+
+        Parameters
+        ----------
+        reference_df : pd.DataFrame, optional
+            Dataset used as reference for binning. Defaults to ``df_train``.
+        bin_strategy : dict, optional
+            ``{"type": "quantile", "n_bins": 10}`` or ``{"type": "fixed"}``.
+        min_obs : int, default 100
+            Minimum observations required per period to compute PSI.
+        eps : float, default 1e-9
+            Small constant added to counts to avoid zeros.
+        save : bool, default False
+            If ``True`` and ``save_dir`` is set, image is written to disk.
+        """
+
         if self.date_col is None:
-            raise ValueError('`date_col` is required for plot_psi().')
+            raise ValueError("`date_col` is required for plot_psi().")
 
-        date_series = pd.to_datetime(self.df_test[self.date_col]).dt.to_period('M')
-        unique_periods = sorted(date_series.unique())
+        reference_df = reference_df if reference_df is not None else self.df_train
+        bin_strategy = bin_strategy or {"type": "quantile", "n_bins": 10}
 
-        psi_records = []
-        baseline_df = self.df_train
+        periods = (
+            pd.to_datetime(self.df_test[self.date_col])
+            .dt.to_period("M")
+            .sort_values()
+            .unique()
+        )
+
+        psi_records: List[Dict[str, Any]] = []
         for var in self._psi_variables():
-            if not pd.api.types.is_numeric_dtype(baseline_df[var]):
+            ref_series = pd.to_numeric(reference_df[var], errors="coerce").dropna()
+            if ref_series.empty:
                 continue
 
-            base_series = pd.to_numeric(baseline_df[var], errors="coerce").dropna()
-            if base_series.empty:
-                continue
-
-            baseline_counts, _ = np.histogram(
-                base_series, bins=bins, range=(base_series.min(), base_series.max())
-            )
-            baseline_pct = baseline_counts / baseline_counts.sum()
-
-            for period in unique_periods:
-                subset = self.df_test[date_series == period]
-                if subset.empty:
-                    continue
-                sub_series = pd.to_numeric(subset[var], errors="coerce").dropna()
-                if sub_series.empty:
-                    counts = np.zeros(bins)
-                else:
-                    counts, _ = np.histogram(
-                        sub_series, bins=bins, range=(base_series.min(), base_series.max())
+            if bin_strategy.get("type") == "quantile":
+                try:
+                    _, edges = pd.qcut(
+                        ref_series,
+                        q=bin_strategy.get("n_bins", 10),
+                        retbins=True,
+                        duplicates="drop",
                     )
-                pct = counts / counts.sum() if counts.sum() > 0 else np.zeros_like(counts)
-                psi = np.where(
-                    (baseline_pct > 0) & (pct > 0),
-                    (pct - baseline_pct) * np.log(pct / baseline_pct),
-                    0,
-                ).sum()
-                psi_records.append({'Variable': var, 'Period': period.to_timestamp(), 'PSI': psi})
+                except ValueError:
+                    edges = np.linspace(
+                        ref_series.min(),
+                        ref_series.max(),
+                        bin_strategy.get("n_bins", 10) + 1,
+                    )
+            else:
+                edges = np.linspace(
+                    ref_series.min(),
+                    ref_series.max(),
+                    bin_strategy.get("n_bins", 10) + 1,
+                )
+
+            edges[0] = min(edges[0], ref_series.min())
+            edges[-1] = max(edges[-1], ref_series.max())
+
+            counts = np.histogram(ref_series, bins=edges)[0].astype(float) + eps
+            p_ref = counts / counts.sum()
+
+            for period in periods:
+                subset = self.df_test[
+                    pd.to_datetime(self.df_test[self.date_col]).dt.to_period("M")
+                    == period
+                ]
+                if len(subset) < min_obs:
+                    continue
+
+                ser = pd.to_numeric(subset[var], errors="coerce").dropna()
+                if ser.empty:
+                    continue
+
+                edges_adj = edges.copy()
+                if ser.min() < edges_adj[0]:
+                    edges_adj[0] = ser.min()
+                if ser.max() > edges_adj[-1]:
+                    edges_adj[-1] = ser.max()
+
+                counts_test = np.histogram(ser, bins=edges_adj)[0].astype(float) + eps
+                p_test = counts_test / counts_test.sum()
+
+                psi = _psi_single(p_ref, p_test)
+                psi_records.append(
+                    {
+                        "Variable": var,
+                        "Period": period.to_timestamp(),
+                        "PSI": psi,
+                    }
+                )
 
         psi_df = pd.DataFrame(psi_records)
         if psi_df.empty:
-            warnings.warn('PSI could not be computed (insufficient data).')
-            return
+            warnings.warn("PSI could not be computed (insufficient data).")
+            return go.Figure()
 
         fig = go.Figure()
-        for var, grp in psi_df.groupby('Variable'):
+        for var, grp in psi_df.groupby("Variable"):
             fig.add_trace(
                 go.Scatter(
-                    x=grp['Period'],
-                    y=grp['PSI'],
-                    mode='lines+markers',
+                    x=grp["Period"],
+                    y=grp["PSI"],
+                    mode="lines+markers",
                     name=str(var),
                 )
             )
-        fig.add_hline(y=0.1, line=dict(color='orange', dash='dash'), annotation_text='0.10')
-        fig.add_hline(y=0.25, line=dict(color='red', dash='dash'), annotation_text='0.25')
+
+        fig.add_hline(
+            y=0.1,
+            line=dict(color="orange", dash="dash"),
+            annotation_text="0.10",
+        )
+        fig.add_hline(
+            y=0.25,
+            line=dict(color="red", dash="dash"),
+            annotation_text="0.25",
+        )
         fig.update_layout(
-            title='PSI over Time by Variable',
-            xaxis_title='Period',
-            yaxis_title='Population Stability Index',
-            template='plotly_white',
+            title="PSI over Time by Variable",
+            xaxis_title="Period",
+            yaxis_title="Population Stability Index",
+            template="plotly_white",
         )
         if save and self.save_dir:
-            fig.write_image(str(self.save_dir / 'psi_over_time.png'))
+            fig.write_image(str(self.save_dir / "psi_over_time.png"))
         return fig
 
     def plot_ks(self, *, save: bool = False) -> go.Figure:
         """KS statistic over time for each split using Plotly."""
         if self.date_col is None:
-            raise ValueError('`date_col` is required for plot_ks().')
+            raise ValueError("`date_col` is required for plot_ks().")
         self._validate_predictors()
 
         def ks_stat(y_true: np.ndarray, y_pred: np.ndarray) -> float:
@@ -378,45 +510,49 @@ class BinaryPerformanceEvaluator:
             return np.max(np.abs(tpr - fpr))
 
         dfs = [
-            ('Train', self.df_train),
-            ('Test', self.df_test),
-            *([('Val', self.df_val)] if self.df_val is not None else []),
+            ("Train", self.df_train),
+            ("Test", self.df_test),
+            *([("Val", self.df_val)] if self.df_val is not None else []),
         ]
 
         ks_records = []
         for split_name, df in dfs:
             df = df.copy()
-            df['Period'] = pd.to_datetime(df[self.date_col]).dt.to_period('M')
-            for period, grp in df.groupby('Period'):
+            df["Period"] = pd.to_datetime(df[self.date_col]).dt.to_period("M")
+            for period, grp in df.groupby("Period"):
                 y_true = grp[self.target_col].values
                 y_pred = self.model.predict_proba(grp[self.predictor_cols])[:, 1]
                 ks = ks_stat(y_true, y_pred)
-                ks_records.append({'Split': split_name, 'Period': period.to_timestamp(), 'KS': ks})
+                ks_records.append(
+                    {"Split": split_name, "Period": period.to_timestamp(), "KS": ks}
+                )
 
         ks_df = pd.DataFrame(ks_records)
         if ks_df.empty:
-            warnings.warn('KS could not be computed (insufficient data).')
+            warnings.warn("KS could not be computed (insufficient data).")
             return
 
         fig = go.Figure()
-        for split, grp in ks_df.groupby('Split'):
+        for split, grp in ks_df.groupby("Split"):
             fig.add_trace(
                 go.Scatter(
-                    x=grp['Period'],
-                    y=grp['KS'],
-                    mode='lines+markers',
+                    x=grp["Period"],
+                    y=grp["KS"],
+                    mode="lines+markers",
                     name=str(split),
                 )
             )
-        fig.add_hline(y=0.05, line=dict(color='gray', dash='dash'), annotation_text='0.05')
+        fig.add_hline(
+            y=0.05, line=dict(color="gray", dash="dash"), annotation_text="0.05"
+        )
         fig.update_layout(
-            title='KS Evolution over Time',
-            xaxis_title='Period',
-            yaxis_title='Kolmogorov–Smirnov',
-            template='plotly_white',
+            title="KS Evolution over Time",
+            xaxis_title="Period",
+            yaxis_title="Kolmogorov–Smirnov",
+            template="plotly_white",
         )
         if save and self.save_dir:
-            fig.write_image(str(self.save_dir / 'ks_evolution.png'))
+            fig.write_image(str(self.save_dir / "ks_evolution.png"))
         return fig
 
     def plot_group_radar(
@@ -492,41 +628,53 @@ class BinaryPerformanceEvaluator:
         """Load model from path or return object as‑is."""
         if isinstance(model, (str, Path)):
             model_path = Path(model)
-            if model_path.suffix in {'.joblib', '.jbl'}:
+            if model_path.suffix in {".joblib", ".jbl"}:
                 return joblib.load(model_path)
-            elif model_path.suffix in {'.pkl', '.pickle'}:
-                with open(model_path, 'rb') as f:
+            elif model_path.suffix in {".pkl", ".pickle"}:
+                with open(model_path, "rb") as f:
                     return pickle.load(f)
             else:
-                raise ValueError(f'Unsupported model file extension: {model_path.suffix}')
+                raise ValueError(
+                    f"Unsupported model file extension: {model_path.suffix}"
+                )
         else:
             # assume object is already a fitted estimator
-            if not hasattr(model, 'predict_proba'):
-                raise AttributeError('Provided model object lacks predict_proba.')
+            if not hasattr(model, "predict_proba"):
+                raise AttributeError("Provided model object lacks predict_proba.")
             return model
 
     def _validate_data(self) -> None:
         """Basic dataframe validations."""
-        for name, df in [('df_train', self.df_train), ('df_test', self.df_test), ('df_val', self.df_val)]:
+        for name, df in [
+            ("df_train", self.df_train),
+            ("df_test", self.df_test),
+            ("df_val", self.df_val),
+        ]:
             if df is None:
                 continue
             if self.target_col not in df.columns:
-                raise KeyError(f'{self.target_col} missing in {name}.')
+                raise KeyError(f"{self.target_col} missing in {name}.")
             if df[self.target_col].isna().any():
-                raise ValueError(f'NaN detected in target column of {name}.')
+                raise ValueError(f"NaN detected in target column of {name}.")
 
             missing_ids = [col for col in self.id_cols if col not in df.columns]
             if missing_ids:
-                raise KeyError(f'{name} missing id_cols: {missing_ids}')
+                raise KeyError(f"{name} missing id_cols: {missing_ids}")
 
         if self.homogeneous_group is None:
             if not self.group_col:
-                raise ValueError('`group_col` must be provided when homogeneous_group is None.')
-            for name, df in [('df_train', self.df_train), ('df_test', self.df_test), ('df_val', self.df_val)]:
+                raise ValueError(
+                    "`group_col` must be provided when homogeneous_group is None."
+                )
+            for name, df in [
+                ("df_train", self.df_train),
+                ("df_test", self.df_test),
+                ("df_val", self.df_val),
+            ]:
                 if df is None:
                     continue
                 if self.group_col not in df.columns:
-                    raise KeyError(f'{name} missing group_col: {self.group_col}')
+                    raise KeyError(f"{name} missing group_col: {self.group_col}")
 
     def _parse_date_col(self) -> None:
         """Parse `date_col` to datetime when format yyyymm is detected."""
@@ -540,7 +688,9 @@ class BinaryPerformanceEvaluator:
             col = df[self.date_col]
             if pd.api.types.is_integer_dtype(col) or pd.api.types.is_float_dtype(col):
                 try:
-                    df[self.date_col] = pd.to_datetime(col.astype(int).astype(str), format="%Y%m")
+                    df[self.date_col] = pd.to_datetime(
+                        col.astype(int).astype(str), format="%Y%m"
+                    )
                     continue
                 except Exception:
                     pass
@@ -561,16 +711,16 @@ class BinaryPerformanceEvaluator:
 
         predictor_cols = sorted(list(cols - exclude))
         if not predictor_cols:
-            raise ValueError('No predictor columns detected after exclusions.')
+            raise ValueError("No predictor columns detected after exclusions.")
         return predictor_cols
 
     def _get_model_feature_names(self) -> Optional[List[str]]:
         """Return feature names used during model training, if available."""
-        if hasattr(self.model, 'feature_names_in_'):
-            return list(getattr(self.model, 'feature_names_in_'))
+        if hasattr(self.model, "feature_names_in_"):
+            return list(getattr(self.model, "feature_names_in_"))
         try:
             booster = self.model.get_booster()
-            if hasattr(booster, 'feature_names'):
+            if hasattr(booster, "feature_names"):
                 return list(booster.feature_names)
         except Exception:
             pass
@@ -578,11 +728,11 @@ class BinaryPerformanceEvaluator:
 
     def _get_model_n_features(self) -> Optional[int]:
         """Return the number of features the model expects, if available."""
-        if hasattr(self.model, 'n_features_in_'):
-            return int(getattr(self.model, 'n_features_in_'))
+        if hasattr(self.model, "n_features_in_"):
+            return int(getattr(self.model, "n_features_in_"))
         try:
             booster = self.model.get_booster()
-            if hasattr(booster, 'num_features'):
+            if hasattr(booster, "num_features"):
                 return int(booster.num_features())
         except Exception:
             pass
@@ -594,49 +744,57 @@ class BinaryPerformanceEvaluator:
             missing = [c for c in self.model_feature_names if c not in cols]
             if missing:
                 raise ValueError(
-                    f'Model expects columns not present in provided data: {missing}'
+                    f"Model expects columns not present in provided data: {missing}"
                 )
             return [c for c in self.model_feature_names if c in cols]
 
         if self.model_n_features is not None and len(cols) != self.model_n_features:
             raise ValueError(
-                f'Number of predictor columns ({len(cols)}) does not match model '
-                f'expectation ({self.model_n_features}).'
+                f"Number of predictor columns ({len(cols)}) does not match model "
+                f"expectation ({self.model_n_features})."
             )
         return cols
 
     def _validate_predictors(self) -> None:
         """Ensure predictor columns align with model expectations."""
-        for name, df in [('df_train', self.df_train), ('df_test', self.df_test), ('df_val', self.df_val)]:
+        for name, df in [
+            ("df_train", self.df_train),
+            ("df_test", self.df_test),
+            ("df_val", self.df_val),
+        ]:
             if df is None:
                 continue
             missing = [c for c in self.predictor_cols if c not in df.columns]
             if missing:
-                raise KeyError(f'{name} missing predictor columns: {missing}')
+                raise KeyError(f"{name} missing predictor columns: {missing}")
 
         if self.model_feature_names:
             ordered = [c for c in self.model_feature_names if c in self.predictor_cols]
             if ordered != self.predictor_cols:
                 self.predictor_cols = ordered
-        elif self.model_n_features is not None and len(self.predictor_cols) != self.model_n_features:
+        elif (
+            self.model_n_features is not None
+            and len(self.predictor_cols) != self.model_n_features
+        ):
             raise ValueError(
-                f'Model expects {self.model_n_features} features, got {len(self.predictor_cols)}'
+                f"Model expects {self.model_n_features} features, got {len(self.predictor_cols)}"
             )
 
     def _score_datasets(self) -> None:
         """Add predicted probabilities and labels to each split."""
-        dfs = [('train', self.df_train), ('test', self.df_test)]
+        dfs = [("train", self.df_train), ("test", self.df_test)]
         if self.df_val is not None:
-            dfs.append(('val', self.df_val))
+            dfs.append(("val", self.df_val))
 
         for name, df in dfs:
             proba = self.model.predict_proba(df[self.predictor_cols])[:, 1]
             df[self.score_col_] = proba
             df[self.label_col_] = (proba >= self.threshold).astype(int)
-            df['Split'] = name.capitalize()
+            df["Split"] = name.capitalize()
 
         self.data_ = pd.concat(
-            [self.df_train, self.df_test] + ([self.df_val] if self.df_val is not None else []),
+            [self.df_train, self.df_test]
+            + ([self.df_val] if self.df_val is not None else []),
             axis=0,
             ignore_index=True,
         )
@@ -649,35 +807,45 @@ class BinaryPerformanceEvaluator:
         self.group_ = {}
 
         if isinstance(self.homogeneous_group, str):
-            if self.homogeneous_group != 'auto':
+            if self.homogeneous_group != "auto":
                 raise ValueError("Unsupported string for homogeneous_group")
 
             optb = OptimalBinning(
-                name='y_proba_train',
-                dtype='numerical',
-                solver='mip',
+                name="y_proba_train",
+                dtype="numerical",
+                solver="mip",
                 min_prebin_size=0.01,
                 max_n_bins=5,
                 min_bin_size=0.05,
-                monotonic_trend='ascending',
+                monotonic_trend="ascending",
             )
-            optb.fit(self.df_train[self.score_col_] * 1000, self.df_train[self.target_col])
+            optb.fit(
+                self.df_train[self.score_col_] * 1000, self.df_train[self.target_col]
+            )
             self.binning_table_ = optb.binning_table.build()
 
-            for name, df in [('train', self.df_train), ('test', self.df_test), ('val', self.df_val)]:
+            for name, df in [
+                ("train", self.df_train),
+                ("test", self.df_test),
+                ("val", self.df_val),
+            ]:
                 if df is None:
                     continue
-                labels = optb.transform(df[self.score_col_] * 1000, metric='bins')
+                labels = optb.transform(df[self.score_col_] * 1000, metric="bins")
                 df[self.group_col_] = labels
                 self.group_[name] = labels
 
         elif isinstance(self.homogeneous_group, int):
             n = int(self.homogeneous_group)
-            for name, df in [('train', self.df_train), ('test', self.df_test), ('val', self.df_val)]:
+            for name, df in [
+                ("train", self.df_train),
+                ("test", self.df_test),
+                ("val", self.df_val),
+            ]:
                 if df is None:
                     continue
                 bins = pd.qcut(
-                    df[self.score_col_].rank(method='first'),
+                    df[self.score_col_].rank(method="first"),
                     q=n,
                     labels=range(1, n + 1),
                 ).astype(int)
@@ -688,11 +856,15 @@ class BinaryPerformanceEvaluator:
         else:
             groups = pd.Series(self.homogeneous_group)
             if len(groups) != len(self.data_):
-                raise ValueError('Length of provided group labels does not match data.')
+                raise ValueError("Length of provided group labels does not match data.")
 
             self.data_[self.group_col_] = groups.reset_index(drop=True)
             start = 0
-            for name, df in [('train', self.df_train), ('test', self.df_test), ('val', self.df_val)]:
+            for name, df in [
+                ("train", self.df_train),
+                ("test", self.df_test),
+                ("val", self.df_val),
+            ]:
                 if df is None:
                     continue
                 end = start + len(df)
@@ -702,11 +874,11 @@ class BinaryPerformanceEvaluator:
             self.binning_table_ = None
 
         self.data_ = pd.concat(
-            [self.df_train, self.df_test] + ([self.df_val] if self.df_val is not None else []),
+            [self.df_train, self.df_test]
+            + ([self.df_val] if self.df_val is not None else []),
             axis=0,
             ignore_index=True,
         )
-
 
     def _psi_variables(self) -> List[str]:
         """Select variables to evaluate for PSI (exclude id/date/target)."""
@@ -714,5 +886,7 @@ class BinaryPerformanceEvaluator:
         if self.date_col:
             exclude.add(self.date_col)
         vars_ = [c for c in self.df_train.columns if c not in exclude]
-        numeric_vars = [v for v in vars_ if pd.api.types.is_numeric_dtype(self.df_train[v])]
+        numeric_vars = [
+            v for v in vars_ if pd.api.types.is_numeric_dtype(self.df_train[v])
+        ]
         return numeric_vars

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -27,7 +27,9 @@ def _create_split():
 
 def test_auto_grouping():
     train, test = _create_split()
-    model = LogisticRegression().fit(train[[f"f{i}" for i in range(5)]], train["target"])
+    model = LogisticRegression().fit(
+        train[[f"f{i}" for i in range(5)]], train["target"]
+    )
 
     evaluator = BinaryPerformanceEvaluator(
         model=model,
@@ -47,7 +49,9 @@ def test_auto_grouping():
 
 def test_radar_plot_returns_figure():
     train, test = _create_split()
-    model = LogisticRegression().fit(train[[f"f{i}" for i in range(5)]], train["target"])
+    model = LogisticRegression().fit(
+        train[[f"f{i}" for i in range(5)]], train["target"]
+    )
 
     evaluator = BinaryPerformanceEvaluator(
         model=model,
@@ -65,7 +69,9 @@ def test_radar_plot_returns_figure():
 
 def test_decile_ks_wrapper():
     train, test = _create_split()
-    model = LogisticRegression().fit(train[[f"f{i}" for i in range(5)]], train["target"])
+    model = LogisticRegression().fit(
+        train[[f"f{i}" for i in range(5)]], train["target"]
+    )
 
     evaluator = BinaryPerformanceEvaluator(
         model=model,
@@ -84,7 +90,9 @@ def test_decile_ks_wrapper():
 
 def test_group_col_required_without_auto():
     train, test = _create_split()
-    model = LogisticRegression().fit(train[[f"f{i}" for i in range(5)]], train["target"])
+    model = LogisticRegression().fit(
+        train[[f"f{i}" for i in range(5)]], train["target"]
+    )
 
     with pytest.raises(ValueError):
         BinaryPerformanceEvaluator(
@@ -100,7 +108,9 @@ def test_group_col_required_without_auto():
 
 def test_event_rate_plot_with_auto_groups():
     train, test = _create_split()
-    model = LogisticRegression().fit(train[[f"f{i}" for i in range(5)]], train["target"])
+    model = LogisticRegression().fit(
+        train[[f"f{i}" for i in range(5)]], train["target"]
+    )
 
     evaluator = BinaryPerformanceEvaluator(
         model=model,

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,46 @@
+import numpy as np
+import pandas as pd
+from sklearn.datasets import make_classification
+from sklearn.linear_model import LogisticRegression
+
+from binary_performance_evaluator import BinaryPerformanceEvaluator, _psi_single
+
+
+def test_psi_single_known_value():
+    base = np.array([0.25, 0.25, 0.25, 0.25])
+    test = np.array([0.2, 0.3, 0.2, 0.3])
+    psi = _psi_single(base, test)
+    assert np.isclose(psi, 0.04054651081081642)
+
+
+def test_plot_confusion_normalization():
+    X, y = make_classification(
+        n_samples=50,
+        n_features=3,
+        n_informative=2,
+        n_redundant=0,
+        random_state=0,
+    )
+    df = pd.DataFrame(X, columns=["a", "b", "c"])
+    df["target"] = y
+    df["id"] = range(len(df))
+    df["date"] = pd.date_range("2020-01-01", periods=len(df))
+
+    train = df.iloc[:30]
+    test = df.iloc[30:]
+
+    model = LogisticRegression().fit(train[["a", "b", "c"]], train["target"])
+    evaluator = BinaryPerformanceEvaluator(
+        model=model,
+        df_train=train,
+        df_test=test,
+        target_col="target",
+        id_cols=["id"],
+        date_col="date",
+    )
+
+    y_true = test["target"]
+    y_pred_proba = model.predict_proba(test[["a", "b", "c"]])[:, 1]
+    fig = evaluator.plot_confusion(y_true, y_pred_proba, normalize=True)
+    cm_abs = np.array(fig.data[0].z)
+    assert np.isclose(cm_abs.sum(), 1.0)


### PR DESCRIPTION
## Summary
- add PSI utility `_psi_single`
- redesign `plot_confusion` with Plotly heatmaps, group support, and ROC-based thresholds
- make PSI computation robust with quantile bins and min obs
- document new features in README
- add `.gitignore` and pre-commit config
- include unit tests for new functions

## Testing
- `black binary_performance_evaluator.py tests/*.py`
- `ruff check binary_performance_evaluator.py tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c7977bc1483218dd853e8b2cec248