### PR TITLE
Add consistent group palette and separate event rate plots

### DIFF
--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -122,8 +122,9 @@ def test_event_rate_plot_with_auto_groups():
         homogeneous_group="auto",
     )
 
-    fig = evaluator.plot_event_rate()
-    assert isinstance(fig, go.Figure)
+    figs = evaluator.plot_event_rate()
+    assert isinstance(figs, tuple) and len(figs) == 2
+    assert all(isinstance(f, go.Figure) for f in figs)
 
 
 def test_binning_table_method():


### PR DESCRIPTION
## Summary
- render event rate plots as two figures instead of subplots
- color groups consistently in event rate and radar plots
- derive palette by sorting groups by event rate
- adapt tests for new return type

## Testing
- `pre-commit run --files binary_performance_evaluator.py tests/test_evaluator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c962f17d8832183acec9a62a2ea58