### PR TITLE
Fix event rate plot display

### DIFF
--- a/binary_performance_evaluator.py
+++ b/binary_performance_evaluator.py
@@ -403,6 +403,10 @@ class BinaryPerformanceEvaluator:
         if save and self.save_dir:
             fig_rate.write_image(str(self.save_dir / "event_rate.png"))
             fig_share.write_image(str(self.save_dir / "group_share.png"))
+
+        fig_rate.show()
+        fig_share.show()
+
         return fig_rate, fig_share
 
     def plot_psi(


### PR DESCRIPTION
## Summary
- show interactive event rate plots automatically

## Testing
- `pre-commit run --files binary_performance_evaluator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c99f1a52083218573df9f67cccd0e