### PR TITLE
Fix compute_metrics return and radar labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ evaluator = BinaryPerformanceEvaluator(
 )
 
 # Calcula métricas
-evaluator.compute_metrics()
+metrics = evaluator.compute_metrics()
 
 # Gráficos
 evaluator.plot_confusion(save=True)
@@ -63,7 +63,7 @@ evaluator.plot_psi()
 evaluator.plot_ks()
 
 # Visualizar resultados numéricos
-print(evaluator.report)
+print(metrics)
 ```
 
 ---
@@ -125,6 +125,7 @@ print(evaluator.report)
 ## 📤 Saídas
 
 - `.report` — dicionário Python contendo todas as métricas numéricas organizadas por split.
+- `compute_metrics()` retorna um `DataFrame` com essas métricas.
 - Gráficos: podem ser exibidos na tela ou salvos em `save_dir`.
 - `evaluator.binning_table()` retorna a tabela de binning (se houver).
 


### PR DESCRIPTION
## Summary
- expose metric table from `compute_metrics`
- hide radial tick labels in radar plot
- update README example and docs about returned metrics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca20b3de48321b67dfd850d4c3525