### PR TITLE
Fix CI by adding seaborn dependency

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,4 +10,5 @@ jobs:
         with:
           python-version: '3.11'
       - run: pip install -e .[dev]
+      - run: pip install seaborn>=0.13
       - run: pytest --cov=riskpilot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,5 @@
 - Packaged RiskPilot using pyproject.toml (PEP 621)
 - Integration of SyntheticVintageGenerator with BinaryPerformanceEvaluator
 - Stress testing pipeline
+### Fixed
+- Added missing `seaborn` dependency (CI failure #123)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ pip install -e .[dev]
 pip install riskpilot
 ```
 
+```bash
+# Optional visualization
+pip install riskpilot[viz]
+```
+
 ---
 
 ## 🚀 Exemplo Rápido

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,11 @@ dependencies = [
   "plotly>=5.20",
   "pyarrow>=15",
   "tqdm>=4.66",
+  "seaborn>=0.13",
 ]
 
 [project.optional-dependencies]
+viz = ["seaborn>=0.13"]
 dev = [
   "pytest>=8",
   "pytest-cov>=4",

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1,0 +1,40 @@
+import numpy as np
+import pandas as pd
+from sklearn.datasets import make_classification
+from sklearn.linear_model import LogisticRegression
+import plotly.graph_objects as go
+
+from riskpilot.evaluation import BinaryPerformanceEvaluator
+
+
+def _split():
+    X, y = make_classification(
+        n_samples=60,
+        n_features=3,
+        n_informative=2,
+        n_redundant=0,
+        random_state=0,
+    )
+    df = pd.DataFrame(X, columns=["a", "b", "c"])
+    df["target"] = y
+    df["id"] = range(len(df))
+    df["date"] = pd.date_range("2020-01-01", periods=len(df))
+    train = df.iloc[:40]
+    test = df.iloc[40:]
+    return train, test
+
+
+def test_seaborn_plots_smoke():
+    train, test = _split()
+    model = LogisticRegression().fit(train[["a", "b", "c"]], train["target"])
+    bev = BinaryPerformanceEvaluator(
+        model=model,
+        df_train=train,
+        df_test=test,
+        target_col="target",
+        id_cols=["id"],
+        date_col="date",
+        homogeneous_group="auto",
+    )
+    figs = bev.plot_event_rate()
+    assert all(isinstance(f, go.Figure) for f in figs)


### PR DESCRIPTION
## Summary
- install seaborn during CI
- expose seaborn as a runtime and optional viz dependency
- document optional visualization installation in the README
- record missing seaborn in the CHANGELOG
- add smoke test for seaborn-based plotting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cbf4d7f6483218c7a3e7d1f00a9f7