### PR TITLE
Fix missing optbinning dependency

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,6 +9,5 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - run: pip install -e .[dev]
-      - run: pip install seaborn>=0.13
+      - run: pip install -e .[dev,binning]
       - run: pytest --cov=riskpilot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,12 @@ dependencies = [
   "pyarrow>=15",
   "tqdm>=4.66",
   "seaborn>=0.13",
+  "optbinning>=0.16",
 ]
 
 [project.optional-dependencies]
 viz = ["seaborn>=0.13"]
+binning = ["optbinning>=0.16"]
 dev = [
   "pytest>=8",
   "pytest-cov>=4",

--- a/riskpilot/evaluation/binary_performance_evaluator.py
+++ b/riskpilot/evaluation/binary_performance_evaluator.py
@@ -50,7 +50,15 @@ import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
 import seaborn as sns
-from optbinning import OptimalBinning
+
+try:
+    from optbinning import OptimalBinning
+except ImportError:  # pragma: no cover - optional dependency
+    OptimalBinning = None  # type: ignore[assignment]
+    logging.warning(
+        "Optional dependency 'optbinning' is missing. "
+        "Install with `pip install riskpilot[binning]`."
+    )
 from sklearn.calibration import calibration_curve
 from sklearn.metrics import (
     average_precision_score,
@@ -964,6 +972,12 @@ class BinaryPerformanceEvaluator:
         if isinstance(self.homogeneous_group, str):
             if self.homogeneous_group != "auto":
                 raise ValueError("Unsupported string for homogeneous_group")
+
+            if OptimalBinning is None:
+                raise ImportError(
+                    "OptimalBinning is required for `homogeneous_group='auto'`. "
+                    "Install with `pip install riskpilot[binning]`."
+                )
 
             optb = OptimalBinning(
                 name="y_proba_train",

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,3 +1,5 @@
+from importlib.util import find_spec
+
 import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
@@ -6,6 +8,11 @@ from sklearn.datasets import make_classification
 from sklearn.linear_model import LogisticRegression
 
 from riskpilot.evaluation import BinaryPerformanceEvaluator
+
+optbinning_available = find_spec("optbinning") is not None
+skip_if_no_optbinning = pytest.mark.skipif(
+    not optbinning_available, reason="optbinning not installed"
+)
 
 
 def _create_split():
@@ -20,6 +27,7 @@ def _create_split():
     return train, test
 
 
+@skip_if_no_optbinning
 def test_auto_grouping():
     train, test = _create_split()
     model = LogisticRegression().fit(
@@ -101,6 +109,7 @@ def test_group_col_required_without_auto():
         )
 
 
+@skip_if_no_optbinning
 def test_event_rate_plot_with_auto_groups():
     train, test = _create_split()
     model = LogisticRegression().fit(
@@ -122,6 +131,7 @@ def test_event_rate_plot_with_auto_groups():
     assert all(isinstance(f, go.Figure) for f in figs)
 
 
+@skip_if_no_optbinning
 def test_binning_table_method():
     train, test = _create_split()
     model = LogisticRegression().fit(

--- a/tests/test_stress_pipeline.py
+++ b/tests/test_stress_pipeline.py
@@ -1,9 +1,15 @@
+from importlib.util import find_spec
+
 import pandas as pd
+import pytest
 from sklearn.datasets import make_classification
 from sklearn.linear_model import LogisticRegression
 
 from riskpilot.evaluation import BinaryPerformanceEvaluator
 from riskpilot.synthetic import SyntheticVintageGenerator
+
+kaleido_available = find_spec("kaleido") is not None
+pytestmark = pytest.mark.skipif(not kaleido_available, reason="kaleido not installed")
 
 
 def test_run_stress_pipeline(tmp_path):

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1,10 +1,17 @@
-import numpy as np
+from importlib.util import find_spec
+
 import pandas as pd
+import plotly.graph_objects as go
+import pytest
 from sklearn.datasets import make_classification
 from sklearn.linear_model import LogisticRegression
-import plotly.graph_objects as go
 
 from riskpilot.evaluation import BinaryPerformanceEvaluator
+
+optbinning_available = find_spec("optbinning") is not None
+skip_if_no_optbinning = pytest.mark.skipif(
+    not optbinning_available, reason="optbinning not installed"
+)
 
 
 def _split():
@@ -24,6 +31,7 @@ def _split():
     return train, test
 
 
+@skip_if_no_optbinning
 def test_seaborn_plots_smoke():
     train, test = _split()
     model = LogisticRegression().fit(train[["a", "b", "c"]], train["target"])


### PR DESCRIPTION
## Summary
- add optbinning requirement and optional extra
- install binning extra in CI workflow
- warn and error gracefully when optbinning is missing
- skip binning-dependent tests when optbinning/kaleido are unavailable

## Testing
- `pre-commit run --files tests/test_stress_pipeline.py tests/test_viz.py tests/test_evaluator.py riskpilot/evaluation/binary_performance_evaluator.py pyproject.toml .github/workflows/python-package.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cc258e24c83218858ecab1eddeba2