### PR TITLE
Handle deprecated pandas freq aliases in SyntheticVintageGenerator

### DIFF
--- a/tests/test_synthetic_gen.py
+++ b/tests/test_synthetic_gen.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import pandas as pd
 
@@ -18,3 +20,17 @@ def test_synthetic_generator_basic():
     synth = gen.generate(n_periods=2, freq="D", n_per_vintage=5)
     assert set(["id", "date", "a", "b"]).issubset(synth.columns)
     assert len(synth) == 10
+
+
+def test_synthetic_generator_deprecated_freq():
+    df = pd.DataFrame(
+        {
+            "id": range(5),
+            "date": pd.date_range("2024-01-01", periods=5, freq="D"),
+        }
+    )
+    gen = SyntheticVintageGenerator(id_cols=["id"], date_cols=["date"])
+    gen.fit(df)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", category=FutureWarning)
+        gen.generate(n_periods=1, freq="M", n_per_vintage=2)


### PR DESCRIPTION
## Summary
- normalize deprecated frequency strings to avoid pandas FutureWarnings
- use normalized offsets in `generate`
- test deprecated frequency support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cd39abab88321836bc007b3fcbd83