### PR TITLE
Add cohort-based PSI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ metrics = evaluator.compute_metrics()
 evaluator.plot_confusion(save=True)
 evaluator.plot_calibration()
 evaluator.plot_event_rate()
-evaluator.plot_psi()
+evaluator.plot_psi(reference_last_period=True)
 evaluator.plot_ks()
 
 # Visualizar resultados numéricos
@@ -109,6 +109,7 @@ print(metrics)
 ### 🧪 PSI por Variável
 - PSI por variável ao longo do tempo (usando `date_col`)
 - Bins por quantis com base em dataset de referência
+- Possibilidade de usar o período imediatamente anterior como referência
 - Tolerante a valores fora do intervalo e períodos com poucos dados
 - Indicação visual de faixas:
   - PSI ≤ 0.10 (aceitável)

--- a/examples/binary_performance_full_demo.ipynb
+++ b/examples/binary_performance_full_demo.ipynb
@@ -6907,9 +6907,9 @@
      "output_type": "display_data"
     }
    ],
-   "source": [
-    "evaluator.plot_psi()"
-   ]
+"source": [
+    "evaluator.plot_psi(reference_last_period=True)"
+]
   },
   {
    "cell_type": "code",

--- a/examples/homogeneous_groups_demo.ipynb
+++ b/examples/homogeneous_groups_demo.ipynb
@@ -20361,8 +20361,8 @@
     }
    ],
    "source": [
-    "# PSI por variável\n",
-    "evaluator.plot_psi()"
+"# PSI por variável\n",
+ "evaluator.plot_psi(reference_last_period=True)"
    ]
   },
   {

--- a/examples/simple_usage.ipynb
+++ b/examples/simple_usage.ipynb
@@ -112,8 +112,8 @@
     "# Taxa de eventos por grupo\n",
     "evaluator.plot_event_rate()\n",
     "\n",
-    "# PSI por variável\n",
-    "evaluator.plot_psi()\n",
+"# PSI por variável\n",
+ "evaluator.plot_psi(reference_last_period=True)\n",
     "\n",
     "# Evolução do KS\n",
     "evaluator.plot_ks()"

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -46,3 +46,21 @@ def test_seaborn_plots_smoke():
     )
     figs = bev.plot_event_rate()
     assert all(isinstance(f, go.Figure) for f in figs)
+
+
+@skip_if_no_optbinning
+def test_plot_psi_last_period():
+    train, test = _split()
+    model = LogisticRegression().fit(train[["a", "b", "c"]], train["target"])
+    bev = BinaryPerformanceEvaluator(
+        model=model,
+        df_train=train,
+        df_test=test,
+        target_col="target",
+        id_cols=["id"],
+        date_col="date",
+        homogeneous_group="auto",
+    )
+    fig, df = bev.plot_psi(reference_last_period=True, min_obs=1)
+    assert isinstance(fig, go.Figure)
+    assert not df.empty and "reference_type" in df.columns


### PR DESCRIPTION
## Summary
- add `reference_last_period` option to `plot_psi`
- return DataFrame with `reference_type`
- document new argument in README and examples
- update notebooks to use the new option
- test PSI month-over-month functionality

## Testing
- `pre-commit run --files riskpilot/evaluation/binary_performance_evaluator.py README.md examples/simple_usage.ipynb examples/binary_performance_full_demo.ipynb examples/homogeneous_groups_demo.ipynb tests/test_viz.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d17a181a88321b7161adbf74433a2