### PR TITLE
Fix PSI plot display

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ print(metrics)
 - Bins por quantis com base em dataset de referência
 - Possibilidade de usar o período imediatamente anterior como referência
 - Tolerante a valores fora do intervalo e períodos com poucos dados
+- É possível ajustar `min_obs` quando um período tem poucos registros
+  (ex.: `evaluator.plot_psi(reference_last_period=True, min_obs=1)`)
 - Indicação visual de faixas:
   - PSI ≤ 0.10 (aceitável)
   - PSI 0.10–0.25 (monitorar)

--- a/riskpilot/evaluation/binary_performance_evaluator.py
+++ b/riskpilot/evaluation/binary_performance_evaluator.py
@@ -533,6 +533,8 @@ class BinaryPerformanceEvaluator:
             If ``True`` each cohort is compared with the immediately
             preceding one. When ``False`` the reference is ``df_train``
             or ``reference_df`` if provided.
+            Periods with fewer than ``min_obs`` records are skipped. Adjust
+            ``min_obs`` (e.g. ``min_obs=1``) if you have short time windows.
         save : bool, default False
             If ``True`` and ``save_dir`` is set, image is written to disk.
 
@@ -725,6 +727,7 @@ class BinaryPerformanceEvaluator:
         )
         if save and self.save_dir:
             fig.write_image(str(self.save_dir / "psi_over_time.png"))
+        fig.show()
         return fig, psi_df
 
     def plot_ks(self, *, save: bool = False, title: str = "") -> go.Figure:


### PR DESCRIPTION
## Summary
- show PSI plot automatically via `fig.show()`
- document `min_obs` tuning when comparing consecutive periods

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d1ca190f48321bb05c963f26e7b2e