### PR TITLE
Improve date continuity for SyntheticVintageGenerator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.3.1] - 2025-07-01
+### Added
+- Temporal continuity and date-precision handling in `SyntheticVintageGenerator`
+
 ## [0.3.0] - 2025-06-14
 ### Added
 - Packaged RiskPilot using pyproject.toml (PEP 621)

--- a/README.md
+++ b/README.md
@@ -147,6 +147,28 @@ resultados/
 
 ---
 
+## Synthetic Vintage Generator
+
+```python
+from riskpilot.synthetic import SyntheticVintageGenerator
+
+gen = SyntheticVintageGenerator(
+    id_cols=["contract_id"],
+    date_cols=["snapshot_date"],
+    random_state=42,
+).fit(df_hist)
+
+df_future = gen.generate(n_periods=36, freq="M")
+```
+
+### Date granularity & plotting
+
+Datas sem componente de hora permanecem como datas puras, evitando rótulos
+``00:00:00`` em gráficos. Se as colunas de data incluírem horas, elas são
+mantidas na geração e nas visualizações.
+
+---
+
 ## 🧪 Testado com
 
 - scikit-learn 1.4+

--- a/riskpilot/evaluation/binary_performance_evaluator.py
+++ b/riskpilot/evaluation/binary_performance_evaluator.py
@@ -245,6 +245,7 @@ class BinaryPerformanceEvaluator:
             n_periods=self.stress_periods,
             freq=self.stress_freq,
             scenario=self.stress_scenario,
+            align_with_history=False,
         )
 
         run_id = uuid.uuid4().hex

--- a/tests/test_synthetic_gen.py
+++ b/tests/test_synthetic_gen.py
@@ -20,6 +20,15 @@ def test_synthetic_generator_basic():
     synth = gen.generate(n_periods=2, freq="D", n_per_vintage=5)
     assert set(["id", "date", "a", "b"]).issubset(synth.columns)
     assert len(synth) == 10
+    assert (synth["date"].dt.normalize() == synth["date"]).all()
+
+
+def test_generate_with_end_vintage():
+    df = pd.DataFrame({"id": range(3), "date": pd.date_range("2024-01-01", periods=3)})
+    gen = SyntheticVintageGenerator(id_cols=["id"], date_cols=["date"]).fit(df)
+    end = df["date"].max() + pd.offsets.Day(5)
+    synth = gen.generate(end_vintage=end, freq="D", n_per_vintage=1)
+    assert synth["date"].max() == end
 
 
 def test_synthetic_generator_deprecated_freq():


### PR DESCRIPTION
## Summary
- support `end_vintage` and `align_with_history` in `SyntheticVintageGenerator`
- keep original date precision when generating cohorts
- update stress test pipeline to keep legacy behaviour
- document synthetic generator
- test new generator features

## Testing
- `pip install -q pandas numpy scikit-learn scipy plotly pyarrow tqdm seaborn optbinning`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d1f9ebd888321b61d7020ee13d996