### PR TITLE
Improve month alignment in SyntheticVintageGenerator

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ gen = SyntheticVintageGenerator(
 df_future = gen.generate(n_periods=36, freq="M")
 ```
 
+Date columns automatically keep their month-start or month-end alignment based on
+the historical data. Mixed patterns default to start-of-month alignment.
+
 ### Date granularity & plotting
 
 Datas sem componente de hora permanecem como datas puras, evitando rótulos

--- a/tests/test_synthetic_gen.py
+++ b/tests/test_synthetic_gen.py
@@ -43,3 +43,21 @@ def test_synthetic_generator_deprecated_freq():
     with warnings.catch_warnings():
         warnings.filterwarnings("error", category=FutureWarning)
         gen.generate(n_periods=1, freq="M", n_per_vintage=2)
+
+
+def test_date_alignment_start():
+    df = pd.DataFrame(
+        {"id": range(3), "date": pd.date_range("2022-01-01", periods=3, freq="MS")}
+    )
+    gen = SyntheticVintageGenerator(id_cols=["id"], date_cols=["date"]).fit(df)
+    synth = gen.generate(n_periods=2, freq="M", n_per_vintage=1)
+    assert synth["date"].dt.is_month_start.all()
+
+
+def test_date_alignment_end():
+    df = pd.DataFrame(
+        {"id": range(3), "date": pd.date_range("2022-01-31", periods=3, freq="M")}
+    )
+    gen = SyntheticVintageGenerator(id_cols=["id"], date_cols=["date"]).fit(df)
+    synth = gen.generate(n_periods=2, freq="M", n_per_vintage=1)
+    assert synth["date"].dt.is_month_end.all()


### PR DESCRIPTION
## Summary
- detect month start/end alignment when fitting vintages
- preserve the alignment when generating data
- make unclear alignment strategy configurable and documented
- test month alignment behaviour

## Testing
- `pre-commit run --files riskpilot/synthetic/synthetic_vintage_generator.py tests/test_synthetic_gen.py README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d9200198c8321b1a0437ed46e0033