### PR TITLE
Enhance SyntheticVintageGenerator date handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [0.3.1] - 2025-07-01
 ### Added
 - Temporal continuity and date-precision handling in `SyntheticVintageGenerator`
+- Native support for integer ``yyyymm``/``yyyymmdd`` dates and skip overlap option
 
 ## [0.3.0] - 2025-06-14
 ### Added

--- a/tests/test_synthetic_gen.py
+++ b/tests/test_synthetic_gen.py
@@ -61,3 +61,22 @@ def test_date_alignment_end():
     gen = SyntheticVintageGenerator(id_cols=["id"], date_cols=["date"]).fit(df)
     synth = gen.generate(n_periods=2, freq="M", n_per_vintage=1)
     assert synth["date"].dt.is_month_end.all()
+
+
+def test_int_yyyymm_roundtrip():
+    df = pd.DataFrame({"id": [1, 2, 3], "date": [202401, 202402, 202403]})
+    orig_dtype = df["date"].dtype
+    gen = SyntheticVintageGenerator(id_cols=["id"], date_cols=["date"])
+    gen.fit(df)
+    synth = gen.generate(n_periods=1, freq="M", n_per_vintage=1)
+    assert synth["date"].dtype == orig_dtype
+    assert (synth["date"] > df["date"].max()).all()
+
+
+def test_no_overlap_with_history():
+    df = pd.DataFrame(
+        {"id": range(3), "date": pd.date_range("2022-01-01", periods=3, freq="MS")}
+    )
+    gen = SyntheticVintageGenerator(id_cols=["id"], date_cols=["date"]).fit(df)
+    synth = gen.generate(n_periods=1, freq="M", n_per_vintage=1)
+    assert synth["date"].min() > df["date"].max()


### PR DESCRIPTION
## Summary
- support integer date formats `yyyymm`/`yyyymmdd`
- ensure generated vintages do not overlap training data
- add unit tests for round-tripping integer dates and avoiding overlap
- update changelog

## Testing
- `black riskpilot/synthetic/synthetic_vintage_generator.py tests/test_synthetic_gen.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d9bf9e2848321933817860ff6b313