### PR TITLE
Improve Sankey migration validation

### DIFF
--- a/riskpilot/evaluation/binary_performance_evaluator.py
+++ b/riskpilot/evaluation/binary_performance_evaluator.py
@@ -1812,8 +1812,40 @@ class BinaryPerformanceEvaluator:
         normalize: bool = False,
         cmap: str = "Blues",
         save: bool = False,
-    ) -> tuple[list[go.Figure] | go.Figure, dict[str, Any]]:
-        """Visualize contract migration between GHs using Sankey diagrams."""
+        raise_on_empty: bool = True,
+    ) -> (
+        tuple[list[go.Figure] | go.Figure, dict[str, Any]]
+        | tuple[None, dict[str, Any]]
+    ):
+        """Visualize contract migration between GHs using Sankey diagrams.
+
+        Parameters
+        ----------
+        start_period, end_period
+            Periods in ``YYYYMM`` or ``YYYY-MM`` format.
+        period_to_period
+            If ``True`` generate a diagram for each consecutive period between
+            ``start_period`` and ``end_period``. Otherwise a single net diagram
+            is returned.
+        money_col
+            Optional column with monetary value to aggregate. When ``None`` the
+            number of contracts is used.
+        top_n
+            Keep only the ``top_n`` flows by value, grouping the remainder as
+            ``Other``.
+        normalize
+            If ``True`` flows are expressed as percentages of the originating
+            group.
+        cmap
+            Colour map used for the node palette.
+        save
+            When ``True`` and ``save_dir`` was provided, images are written to
+            disk.
+        raise_on_empty
+            When ``True`` (default) a :class:`ValueError` is raised if no flows
+            are found between the selected periods. If ``False`` an empty result
+            ``(None, {})`` is returned instead.
+        """
 
         import numpy as np
         import pandas as pd
@@ -1823,6 +1855,11 @@ class BinaryPerformanceEvaluator:
 
         if self.date_col is None:
             raise ValueError("`date_col` é obrigatório para plot_sankey_migration().")
+
+        df_all = self.data_.copy()
+        df_all[self.date_col] = pd.to_datetime(df_all[self.date_col]).dt.to_period("M")
+        if df_all[self.date_col].isna().any():
+            raise ValueError("date_col contains NaT values – check parsing.")
 
         gh_col = next(
             (
@@ -1836,9 +1873,9 @@ class BinaryPerformanceEvaluator:
             raise ValueError("Group column não encontrado para Sankey.")
 
         id_col = self.id_cols[0]
-
-        df_all = self.data_.copy()
-        df_all[self.date_col] = pd.to_datetime(df_all[self.date_col]).dt.to_period("M")
+        if df_all[gh_col].isna().any():
+            raise ValueError("gh_col has missing values; compute groups first.")
+        df_all[id_col] = df_all[id_col].astype(str)
 
         start_p = pd.Period(str(start_period), freq="M")
         end_p = pd.Period(str(end_period), freq="M")
@@ -1875,9 +1912,20 @@ class BinaryPerformanceEvaluator:
 
         def _one_sankey(
             p1: pd.Period, p2: pd.Period
-        ) -> tuple[go.Figure, dict[str, Any]]:
-            df_start = df_all[df_all[self.date_col] == p1]
-            df_end = df_all[df_all[self.date_col] == p2][[id_col, gh_col]]
+        ) -> tuple[go.Figure | None, dict[str, Any]]:
+            df_start = df_all[df_all[self.date_col] == p1].copy()
+            df_end = df_all[df_all[self.date_col] == p2][[id_col, gh_col]].copy()
+
+            df_start[id_col] = df_start[id_col].astype(str)
+            df_end[id_col] = df_end[id_col].astype(str)
+
+            logger.info(
+                "Period %s: %d contracts, Period %s: %d contracts",
+                p1,
+                len(df_start),
+                p2,
+                len(df_end),
+            )
 
             cross = (
                 df_start.merge(df_end, on=id_col, suffixes=("_start", "_end"))
@@ -1887,6 +1935,18 @@ class BinaryPerformanceEvaluator:
                     columns={f"{gh_col}_start": "gh_start", f"{gh_col}_end": "gh_end"}
                 )
             )
+
+            logger.info("After merge: %d flows", len(cross))
+
+            if cross.empty:
+                msg = (
+                    f"No migrations found between {p1.strftime('%Y-%m')} and {p2.strftime('%Y-%m')}. "
+                    "Verify id_col overlap and homogeneous groups."
+                )
+                if raise_on_empty:
+                    raise ValueError(msg)
+                logger.warning(msg)
+                return None, {}
 
             if normalize and not cross.empty:
                 cross["value"] = cross["value"] / cross.groupby("gh_start")[
@@ -1991,7 +2051,8 @@ class BinaryPerformanceEvaluator:
             for p1, p2 in zip(period_range[:-1], period_range[1:]):
                 logger.info("Gerando Sankey %s → %s", p1, p2)
                 fig, met = _one_sankey(p1, p2)
-                fig_list.append(fig)
+                if fig is not None:
+                    fig_list.append(fig)
                 metrics_dict[f"{p1.strftime('%Y%m')}->{p2.strftime('%Y%m')}"] = met
             return fig_list, metrics_dict
 

--- a/tests/test_sankey.py
+++ b/tests/test_sankey.py
@@ -1,0 +1,66 @@
+import pandas as pd
+import numpy as np
+import plotly.graph_objects as go
+import pytest
+from sklearn.linear_model import LogisticRegression
+
+from riskpilot.evaluation import BinaryPerformanceEvaluator
+
+
+def _make_df(overlap=True, mismatch_dtype=False):
+    rng = np.random.RandomState(0)
+    n = 20
+    X1 = rng.randn(n, 3)
+    X2 = rng.randn(n, 3)
+    df1 = pd.DataFrame(X1, columns=["a", "b", "c"])
+    df2 = pd.DataFrame(X2, columns=["a", "b", "c"])
+    df1["target"] = rng.randint(0, 2, n)
+    df2["target"] = rng.randint(0, 2, n)
+    df1["id"] = np.arange(n)
+    df2_ids = np.arange(n) if overlap else np.arange(n, 2 * n)
+    if mismatch_dtype:
+        df2["id"] = [f"A{i}" for i in df2_ids]
+    else:
+        df2["id"] = df2_ids
+    df1["date"] = pd.Timestamp("2022-01-01")
+    df2["date"] = pd.Timestamp("2022-02-01")
+    return df1.reset_index(drop=True), df2.reset_index(drop=True)
+
+
+def _evaluator(df1, df2):
+    model = LogisticRegression().fit(
+        pd.concat([df1, df2])[["a", "b", "c"]],
+        pd.concat([df1, df2])["target"],
+    )
+    return BinaryPerformanceEvaluator(
+        model=model,
+        df_train=df1,
+        df_test=df2,
+        target_col="target",
+        id_cols=["id"],
+        date_col="date",
+        homogeneous_group=2,
+    )
+
+
+def test_sankey_normal_case():
+    df1, df2 = _make_df()
+    bev = _evaluator(df1, df2)
+    figs, metrics = bev.plot_sankey_migration("2022-01", "2022-02")
+    assert isinstance(figs, list) and isinstance(figs[0], go.Figure)
+    assert len(figs[0].data[0].link.value) > 0
+    assert metrics
+
+
+def test_sankey_no_overlap():
+    df1, df2 = _make_df(overlap=False)
+    bev = _evaluator(df1, df2)
+    with pytest.raises(ValueError):
+        bev.plot_sankey_migration("2022-01", "2022-02")
+
+
+def test_sankey_mismatched_dtype():
+    df1, df2 = _make_df(mismatch_dtype=True)
+    bev = _evaluator(df1, df2)
+    with pytest.raises(ValueError):
+        bev.plot_sankey_migration("2022-01", "2022-02")


### PR DESCRIPTION
## Summary
- detect empty migrations in `plot_sankey_migration`
- add `raise_on_empty` option and improve logging
- handle id/group validation and dtype casting
- add regression tests for Sankey migration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e390be8ec832198653659a3f55559