### PR TITLE
Improve error for missing kaleido

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ pip install riskpilot
 ```bash
 # Optional visualization
 pip install riskpilot[viz]
+pip install kaleido  # required for saving Plotly figures as images
 ```
 
 ---

--- a/riskpilot/evaluation/binary_performance_evaluator.py
+++ b/riskpilot/evaluation/binary_performance_evaluator.py
@@ -305,7 +305,15 @@ class BinaryPerformanceEvaluator:
             out = func()
             if isinstance(out, go.Figure):
                 fig_path = art_dir / f"{name}.png"
-                out.write_image(fig_path)
+                try:
+                    out.write_image(fig_path)
+                except ValueError as err:
+                    if "kaleido" in str(err).lower():
+                        raise RuntimeError(
+                            "Plotly image export requires the 'kaleido' package. "
+                            "Install it with 'pip install kaleido'."
+                        ) from err
+                    raise
                 results[name] = str(fig_path)
             else:
                 results[name] = out


### PR DESCRIPTION
## Summary
- show a clearer message when Kaleido is missing
- document Kaleido dependency in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e3d5058bc83218c08e7ffda42f25f