### PR TITLE
Implement export_report utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,19 @@ resultados/
 └── ks_evolution.png
 ```
 
+### Exporting artefacts
+
+```python
+figs = evaluator.plot_shap(plot_type="bar", save=False)
+exp_dir = evaluator.export_report(
+    figs=figs,
+    summary_df=summary_df,
+    bullets=bullets,
+    formats=("png", "svg", "html"),
+)
+print(f"Report written to → {exp_dir}")
+```
+
 ---
 
 ## LookAhead Generator

--- a/riskpilot/evaluation/binary_performance_evaluator.py
+++ b/riskpilot/evaluation/binary_performance_evaluator.py
@@ -46,13 +46,13 @@ import hashlib
 import logging
 import math
 import pickle
+import shutil
 import uuid
 import warnings
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union
-
-import riskpilot
 
 import joblib
 import numpy as np
@@ -60,6 +60,8 @@ import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
 import seaborn as sns
+
+import riskpilot
 
 try:
     from optbinning import OptimalBinning
@@ -70,14 +72,9 @@ except ImportError:  # pragma: no cover - optional dependency
         "Install with `pip install riskpilot[binning]`."
     )
 from sklearn.linear_model import LogisticRegression
-from sklearn.metrics import (
-    average_precision_score,
-    brier_score_loss,
-    matthews_corrcoef,
-    precision_score,
-    recall_score,
-    roc_auc_score,
-)
+from sklearn.metrics import (average_precision_score, brier_score_loss,
+                             matthews_corrcoef, precision_score, recall_score,
+                             roc_auc_score)
 
 try:
     import shap
@@ -3822,32 +3819,69 @@ class BinaryPerformanceEvaluator:
         )
         return self._build_shap_waterfall(expl, index=index, max_display=max_display)
 
-    def _export_shap_outputs(
+    def export_report(
         self,
-        figures: list[go.Figure],
-        summary_df: pd.DataFrame,
-        bullets: list[str] | None,
         *,
-        save: bool,
-        save_format: str | Sequence[str],
-    ) -> None:
-        """Save SHAP artefacts if requested (placeholder implementation)."""
+        figs: go.Figure | Sequence[go.Figure] | Mapping[str, go.Figure],
+        summary_df: pd.DataFrame | None = None,
+        bullets: list[str] | None = None,
+        export_dir: str | Path | None = None,
+        formats: Sequence[str] = ("png",),
+        name_prefix: str = "shap",
+        dpi: int = 150,
+        zip_bundle: bool = True,
+    ) -> Path:
+        """Persist figures and data to disk.
 
-        if not save or self.save_dir is None:
-            return
+        Returns
+        -------
+        Path
+            Directory containing the exported files.
+        """
 
-        formats = [save_format] if isinstance(save_format, str) else list(save_format)
-        for i, fig in enumerate(figures):
-            for fmt in formats:
-                path = self.save_dir / f"shap_{i}.{fmt}"
+        ts = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+        base = Path(export_dir or self.save_dir or ".")
+        exp_dir = base / f"report_{ts}"
+        exp_dir.mkdir(parents=True, exist_ok=True)
+
+        def _save_fig(name: str, fig: go.Figure) -> None:
+            for ext in formats:
+                fpath = exp_dir / f"{name}.{ext}"
                 try:
-                    fig.write_image(path)
+                    if ext == "html":
+                        fig.write_html(fpath, full_html=False, include_plotlyjs="cdn")
+                    else:
+                        fig.write_image(fpath, scale=dpi / 72)
                 except ValueError as err:
                     if "kaleido" in str(err).lower():
                         raise RuntimeError(
-                            "Plotly image export requires the 'kaleido' package. Install it with 'pip install kaleido'."
+                            "Static export requires the 'kaleido' package. Try `pip install kaleido`."
                         ) from err
                     raise
+
+        if isinstance(figs, go.Figure):
+            _save_fig("fig_0", figs)
+        elif isinstance(figs, Mapping):
+            for name, fig in figs.items():
+                _save_fig(name, fig)
+        else:
+            for i, fig in enumerate(figs):
+                _save_fig(f"fig_{i}", fig)
+
+        if summary_df is not None:
+            summary_df.to_csv(exp_dir / f"{name_prefix}_summary.csv", index=False)
+            summary_df.to_html(exp_dir / f"{name_prefix}_summary.html", index=False)
+
+        if bullets:
+            (exp_dir / "insights.txt").write_text("\n".join(bullets), encoding="utf-8")
+
+        if zip_bundle:
+            try:
+                shutil.make_archive(str(exp_dir), "zip", root_dir=exp_dir)
+            except Exception:
+                pass
+
+        return exp_dir
 
     def plot_shap(
         self,
@@ -3870,6 +3904,7 @@ class BinaryPerformanceEvaluator:
         summary: bool = False,
         save: bool = False,
         save_format: str | Sequence[str] = "png",
+        zip_bundle: bool = False,
         return_data: bool = False,
         **kwargs,
     ) -> go.Figure | list[go.Figure] | dict[str, Any]:
@@ -3980,8 +4015,12 @@ class BinaryPerformanceEvaluator:
         )
 
         if save:
-            self._export_shap_outputs(
-                figs, summary_df, bullets, save=save, save_format=save_format
+            self.export_report(
+                figs=figs,
+                summary_df=summary_df,
+                bullets=bullets,
+                formats=(save_format,) if isinstance(save_format, str) else save_format,
+                zip_bundle=zip_bundle,
             )
 
         result: go.Figure | list[go.Figure] | dict[str, Any]

--- a/tests/test_export_report.py
+++ b/tests/test_export_report.py
@@ -1,0 +1,72 @@
+from importlib.util import find_spec
+
+import pandas as pd
+import plotly.graph_objects as go
+import pytest
+from sklearn.datasets import make_classification
+from sklearn.linear_model import LogisticRegression
+
+from riskpilot.evaluation import BinaryPerformanceEvaluator
+
+kaleido_available = find_spec("kaleido") is not None
+pytestmark = pytest.mark.skipif(not kaleido_available, reason="kaleido not installed")
+
+
+def _evaluator(tmp_path):
+    X, y = make_classification(
+        n_samples=20,
+        n_features=2,
+        n_informative=2,
+        n_redundant=0,
+        random_state=0,
+    )
+    df = pd.DataFrame(X, columns=["a", "b"])
+    df["target"] = y
+    df["id"] = range(len(df))
+    train = df.iloc[:10].reset_index(drop=True)
+    test = df.iloc[10:].reset_index(drop=True)
+    model = LogisticRegression().fit(train[["a", "b"]], train["target"])
+    return BinaryPerformanceEvaluator(
+        model=model,
+        df_train=train,
+        df_test=test,
+        target_col="target",
+        id_cols=["id"],
+        save_dir=tmp_path,
+    )
+
+
+def test_export_paths_exist(tmp_path):
+    bev = _evaluator(tmp_path)
+    fig = go.Figure(go.Scatter(x=[0, 1], y=[0, 1]))
+    df = pd.DataFrame(
+        {
+            "feature": ["a"],
+            "split": ["train"],
+            "importance": [0.5],
+            "variation_flag": [False],
+        }
+    )
+    out_dir = bev.export_report(
+        figs=fig, summary_df=df, bullets=["ok"], export_dir=tmp_path
+    )
+    assert any(out_dir.glob("*.png"))
+    assert (out_dir / "shap_summary.csv").is_file()
+    assert (out_dir / "shap_summary.html").is_file()
+    assert (out_dir / "insights.txt").is_file()
+
+
+def test_export_zip(tmp_path):
+    bev = _evaluator(tmp_path)
+    fig = go.Figure(go.Scatter(x=[0, 1], y=[0, 1]))
+    out_dir = bev.export_report(figs=fig, export_dir=tmp_path, zip_bundle=True)
+    zip_path = out_dir.with_suffix(".zip")
+    assert zip_path.is_file()
+
+
+def test_export_multiple_formats(tmp_path):
+    bev = _evaluator(tmp_path)
+    fig = go.Figure(go.Scatter(x=[0, 1], y=[0, 1]))
+    out_dir = bev.export_report(figs=fig, export_dir=tmp_path, formats=("png", "svg"))
+    assert (out_dir / "fig_0.png").is_file()
+    assert (out_dir / "fig_0.svg").is_file()

--- a/tests/test_plot_shap.py
+++ b/tests/test_plot_shap.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pandas as pd
 import plotly.graph_objects as go
 import pytest
@@ -42,7 +44,7 @@ def test_plot_shap_smoke(plot_type, monkeypatch):
         date_col="date",
     )
 
-    monkeypatch.setattr(bev, "_export_shap_outputs", lambda *a, **k: None)
+    monkeypatch.setattr(bev, "export_report", lambda *a, **k: Path("."))
 
     kwargs = {"max_display": 3}
     if plot_type in {"dependence", "trend"}:


### PR DESCRIPTION
## Summary
- add export_report method for saving figures and summaries
- integrate export_report into plot_shap
- document artefact export usage
- test export_report functionality

## Testing
- `pytest tests/test_export_report.py::test_export_paths_exist -q` *(fails: ChromeNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6854d72b76d883218136e5238e5a46aa