### PR TITLE
Refactor SHAP defaults and explainer logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,9 @@ exp_dir = evaluator.export_report(
 print(f"Report written to → {exp_dir}")
 ```
 
+SHAP values are not cached by default. Pass ``use_cache=True`` or set the
+environment variable ``BPE_SHAP_CACHE=1`` if you need to persist them.
+
 ---
 
 ## LookAhead Generator

--- a/docs/index.html
+++ b/docs/index.html
@@ -93,6 +93,11 @@ fig.show()
     <p>Install the optional <code>viz</code> extra:<br>
        <code>pip install riskpilot[viz]</code></p>
   </details>
+  <details><summary>My notebook cell never finishes</summary>
+    <p>Check the logs for a warning that <code>shap.KernelExplainer</code> was used.
+       This fallback can be extremely slow. Switch to a tree or linear model or
+       sample your data.</p>
+  </details>
 </section>
 
 <footer>

--- a/riskpilot/__init__.py
+++ b/riskpilot/__init__.py
@@ -1,9 +1,12 @@
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 
 from .evaluation import BinaryPerformanceEvaluator, decile_analysis_plot
 from .synthetic import LookAhead
 
-__version__ = version("riskpilot")
+try:
+    __version__ = version("riskpilot")
+except PackageNotFoundError:  # pragma: no cover - fallback during tests
+    __version__ = "0.0.0"
 
 __all__ = [
     "BinaryPerformanceEvaluator",

--- a/riskpilot/evaluation/binary_performance_evaluator.py
+++ b/riskpilot/evaluation/binary_performance_evaluator.py
@@ -47,6 +47,7 @@ import logging
 import math
 import pickle
 import shutil
+import os
 import uuid
 import warnings
 from collections.abc import Mapping, Sequence
@@ -71,10 +72,22 @@ except ImportError:  # pragma: no cover - optional dependency
         "Optional dependency 'optbinning' is missing. "
         "Install with `pip install riskpilot[binning]`."
     )
-from sklearn.linear_model import LogisticRegression
-from sklearn.metrics import (average_precision_score, brier_score_loss,
-                             matthews_corrcoef, precision_score, recall_score,
-                             roc_auc_score)
+from sklearn.linear_model import (
+    LogisticRegression,
+    LinearRegression,
+    SGDClassifier,
+    SGDRegressor,
+)
+from sklearn.ensemble import RandomForestClassifier, GradientBoostingClassifier
+from sklearn.tree import DecisionTreeClassifier
+from sklearn.metrics import (
+    average_precision_score,
+    brier_score_loss,
+    matthews_corrcoef,
+    precision_score,
+    recall_score,
+    roc_auc_score,
+)
 
 try:
     import shap
@@ -2884,19 +2897,44 @@ class BinaryPerformanceEvaluator:
             )
 
         model = self.model
-        if (XGBModel is not object and isinstance(model, XGBModel)) or (
-            LGBMModel is not object and isinstance(model, LGBMModel)
+        if (
+            (XGBModel is not object and isinstance(model, XGBModel))
+            or (LGBMModel is not object and isinstance(model, LGBMModel))
+            or isinstance(
+                model,
+                (
+                    RandomForestClassifier,
+                    GradientBoostingClassifier,
+                    DecisionTreeClassifier,
+                ),
+            )
         ):
             explainer = shap.TreeExplainer(model)
-        elif isinstance(model, LogisticRegression):
+        elif isinstance(
+            model,
+            (
+                LogisticRegression,
+                LinearRegression,
+                SGDClassifier,
+                SGDRegressor,
+            ),
+        ):
             X_train = self.df_train[self.predictor_cols]
-            explainer = shap.LinearExplainer(model, X_train)
+            explainer = shap.LinearExplainer(
+                model, X_train, feature_perturbation="interventional"
+            )
         else:
+            logger = logging.getLogger("riskpilot")
             X_train = self.df_train[self.predictor_cols]
             background = (
                 shap.sample(X_train, 100, random_state=42)
                 if len(X_train) > 100
                 else X_train
+            )
+            logger.warning(
+                "\u26a0\ufe0f Falling back to shap.KernelExplainer. This could be "
+                "very slow for large datasets and many features. Consider using "
+                "a tree or linear model, or sample your data."
             )
             explainer = shap.KernelExplainer(
                 lambda m: model.predict_proba(m)[:, self._pos_class_idx],
@@ -2961,7 +2999,7 @@ class BinaryPerformanceEvaluator:
         return explanation
 
     def _compute_shap_values(
-        self, X: pd.DataFrame, *, split_name: str, use_cache: bool = True
+        self, X: pd.DataFrame, *, split_name: str, use_cache: bool = False
     ) -> "shap.Explanation":
         """Compute SHAP values for a pre-processed feature matrix.
 
@@ -2973,6 +3011,9 @@ class BinaryPerformanceEvaluator:
         ----------
         X : pandas.DataFrame
             Feature matrix with the same columns and order as ``self.predictor_cols``.
+        use_cache : bool, default ``False``
+            Persist SHAP values in-memory and on-disk. Can be globally enabled by
+            setting the environment variable ``BPE_SHAP_CACHE=1``.
 
         Returns
         -------
@@ -2985,6 +3026,13 @@ class BinaryPerformanceEvaluator:
                 "SHAP visualisations need the optional dependency 'shap'. "
                 "Install with `pip install riskpilot[viz]`."
             )
+
+        if os.getenv("BPE_SHAP_CACHE", "0") == "1":
+            use_cache = True
+
+        logger = logging.getLogger("riskpilot")
+        if not use_cache:
+            logger.debug("SHAP caching disabled (use_cache=False)")
 
         expected_cols = list(getattr(self, "feature_names_", self.predictor_cols))
         if list(X.columns) != expected_cols:

--- a/tests/test_shap_cache.py
+++ b/tests/test_shap_cache.py
@@ -1,4 +1,6 @@
+import os
 import time
+import joblib
 import numpy as np
 import pandas as pd
 from sklearn.datasets import make_classification
@@ -50,27 +52,61 @@ def _evaluator(tmp_path, monkeypatch):
 def test_cache_hit(tmp_path, monkeypatch):
     bev = _evaluator(tmp_path, monkeypatch)
     t0 = time.time()
-    bev._compute_shap_values(bev.df_train[bev.predictor_cols], split_name="train")
+    bev._compute_shap_values(
+        bev.df_train[bev.predictor_cols], split_name="train", use_cache=True
+    )
     t1 = time.time() - t0
     t0 = time.time()
-    bev._compute_shap_values(bev.df_train[bev.predictor_cols], split_name="train")
+    bev._compute_shap_values(
+        bev.df_train[bev.predictor_cols], split_name="train", use_cache=True
+    )
     t2 = time.time() - t0
     assert t2 < t1 * 0.5
 
 
 def test_disk_cache(tmp_path, monkeypatch):
     bev1 = _evaluator(tmp_path, monkeypatch)
-    bev1._compute_shap_values(bev1.df_train[bev1.predictor_cols], split_name="train")
+    bev1._compute_shap_values(
+        bev1.df_train[bev1.predictor_cols], split_name="train", use_cache=True
+    )
     bev2 = _evaluator(tmp_path, monkeypatch)
-    bev2._compute_shap_values(bev2.df_train[bev2.predictor_cols], split_name="train")
+    bev2._compute_shap_values(
+        bev2.df_train[bev2.predictor_cols], split_name="train", use_cache=True
+    )
     assert bev2.cache_stats()["disk_hits"] == 1
 
 
 def test_clear_cache(tmp_path, monkeypatch):
     bev = _evaluator(tmp_path, monkeypatch)
-    bev._compute_shap_values(bev.df_train[bev.predictor_cols], split_name="train")
+    bev._compute_shap_values(
+        bev.df_train[bev.predictor_cols], split_name="train", use_cache=True
+    )
     path = bev._cache_path("train")
     assert path.is_file()
     bev.clear_shap_cache()
     assert not path.exists()
     assert bev.cache_stats()["size_mb"] == 0
+
+
+def test_no_cache_by_default(tmp_path, monkeypatch):
+    bev = _evaluator(tmp_path, monkeypatch)
+
+    called = False
+
+    def fake_dump(*args, **kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(joblib, "dump", fake_dump)
+    bev._compute_shap_values(bev.df_train[bev.predictor_cols], split_name="train")
+    assert not called
+
+
+def test_env_var_enables_cache(tmp_path, monkeypatch):
+    os.environ["BPE_SHAP_CACHE"] = "1"
+    try:
+        bev = _evaluator(tmp_path, monkeypatch)
+        bev._compute_shap_values(bev.df_train[bev.predictor_cols], split_name="train")
+        assert bev._cache_path("train").is_file()
+    finally:
+        os.environ.pop("BPE_SHAP_CACHE", None)

--- a/tests/test_shap_explainer.py
+++ b/tests/test_shap_explainer.py
@@ -1,0 +1,56 @@
+import logging
+import pandas as pd
+from sklearn.datasets import make_classification
+from sklearn.linear_model import LogisticRegression
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.neighbors import KNeighborsClassifier
+
+from riskpilot.evaluation import BinaryPerformanceEvaluator
+from tests.conftest import shap_available
+
+
+@shap_available
+def test_explainer_selection(caplog):
+    import shap
+
+    X, y = make_classification(n_samples=50, n_features=4, random_state=0)
+    df = pd.DataFrame(X, columns=[f"f{i}" for i in range(4)])
+    df["target"] = y
+    df["id"] = range(len(df))
+    train = df.iloc[:40].reset_index(drop=True)
+    test = df.iloc[40:].reset_index(drop=True)
+
+    rf = RandomForestClassifier(n_estimators=5, random_state=0).fit(
+        train[[f"f{i}" for i in range(4)]], train["target"]
+    )
+    bev_rf = BinaryPerformanceEvaluator(
+        model=rf,
+        df_train=train,
+        df_test=test,
+        target_col="target",
+        id_cols=["id"],
+    )
+    assert isinstance(bev_rf._get_shap_explainer(), shap.TreeExplainer)
+
+    lr = LogisticRegression().fit(train[[f"f{i}" for i in range(4)]], train["target"])
+    bev_lr = BinaryPerformanceEvaluator(
+        model=lr,
+        df_train=train,
+        df_test=test,
+        target_col="target",
+        id_cols=["id"],
+    )
+    assert isinstance(bev_lr._get_shap_explainer(), shap.LinearExplainer)
+
+    kn = KNeighborsClassifier().fit(train[[f"f{i}" for i in range(4)]], train["target"])
+    bev_kn = BinaryPerformanceEvaluator(
+        model=kn,
+        df_train=train,
+        df_test=test,
+        target_col="target",
+        id_cols=["id"],
+    )
+    with caplog.at_level(logging.WARNING):
+        expl = bev_kn._get_shap_explainer()
+    assert isinstance(expl, shap.KernelExplainer)
+    assert any("KernelExplainer" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- avoid PackageNotFoundError on local installs
- disable SHAP caching by default and add environment override
- warn when falling back to KernelExplainer
- update docs with troubleshooting tip
- expand SHAP cache tests and add explainer selection test

## Testing
- `black riskpilot/evaluation/binary_performance_evaluator.py tests/test_shap_cache.py tests/test_shap_explainer.py riskpilot/__init__.py`
- `ruff check riskpilot/evaluation/binary_performance_evaluator.py tests/test_shap_cache.py tests/test_shap_explainer.py riskpilot/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854e665abc08321a59b92f1f0885ca5